### PR TITLE
Update build_release_binaries.yml

### DIFF
--- a/.github/workflows/build_release_binaries.yml
+++ b/.github/workflows/build_release_binaries.yml
@@ -6,6 +6,10 @@ on:
     branches: 
     - main
     - release/*
+
+permissions:
+  contents: write
+  
 jobs:
 
   build:


### PR DESCRIPTION
Description of change
Created a git hub action event based on 'release' to build binaries and upload it to the Release Artifacts

Notes
Upon creation/publication of a Release, the build release binary will create and upload a Windows, Mac, and Ubuntu binary.